### PR TITLE
Allow building with `happy-2.1.1` or later

### DIFF
--- a/language-rust.cabal
+++ b/language-rust.cabal
@@ -41,8 +41,8 @@ library
                        -Wincomplete-uni-patterns
                        -Wmissing-signatures
 
-  build-tools:         alex >=3.1, happy >=1.19.8 && < 2.1
-  -- We restrict to < 2.1, because of
+  build-tools:         alex >=3.1, happy >=1.19.8 && < 2.1 || >= 2.1.1
+  -- We restrict to < 2.1 || >= 2.1.1, because of
   -- https://github.com/haskell/happy/issues/320
 
   default-language:    Haskell2010


### PR DESCRIPTION
`happy-2.1.1` includes a fix for https://github.com/haskell/happy/issues/320, which was preventing `language-rust` from building. Now that this version of `happy` is on Hackage, we no longer need to include such a restrictive upper version bound on `happy`.